### PR TITLE
Fix invalid main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ansi-mark",
-	"main": "ansi-mark",
+	"main": "index.js",
 	"version": "1.0.4",
 	"description": "🖊️  a highlight marker for your color ansi strings",
 	"license": "MIT",


### PR DESCRIPTION
Points the main field to the script entry point.

```
(node:15953) [DEP0128] DeprecationWarning: Invalid 'main' field in 'node_modules/ansi-mark/package.json' of 'ansi-mark'. Please either fix that or report it to the module author
```